### PR TITLE
Persist stored filenames for shared files

### DIFF
--- a/Blockchain_client/templates/view_transactions.html
+++ b/Blockchain_client/templates/view_transactions.html
@@ -181,8 +181,10 @@ function renderTxRow(blockIndex, blockTimestamp, tx) {
   if (tx.is_sensitive === "1") {
     fileCell = `<span style="color:red;">(SENSITIVE - hidden)</span>`;
   } else {
-    if (tx.file_name) {
-      fileCell = `<span class="file-link" data-file="${tx.file_name}">${tx.file_name}</span>`;
+    const storedName = tx.stored_file_name || tx.file_name;
+    const displayName = tx.file_name || storedName || "";
+    if (storedName) {
+      fileCell = `<span class="file-link" data-file="${storedName}">${displayName}</span>`;
     }
   }
 
@@ -244,6 +246,7 @@ function matchesTransaction(tx, searchText) {
     ${tx.sender}
     ${tx.recipient}
     ${tx.file_name}
+    ${tx.stored_file_name}
     ${tx.alias}
     ${tx.recipient_alias}
     ${tx.blockTimestamp}
@@ -283,7 +286,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (evt.target.classList.contains('file-link')) {
       const fname = evt.target.getAttribute('data-file');
       if (fname) {
-        window.open(nodeUrl + "/file/" + fname, "_blank");
+        window.open(nodeUrl + "/file/" + encodeURIComponent(fname), "_blank");
       }
     }
   });


### PR DESCRIPTION
## Summary
- store the finalized on-disk filename with each transaction and include it in broadcasts
- serve files and decrypt sensitive uploads using the stored filename while keeping the display name intact
- teach the client UI to open files by stored name and add regression coverage for file serving and sync

## Testing
- pytest tests/test_blockchain.py


------
https://chatgpt.com/codex/tasks/task_e_68de176059f483229ffc49ea18843a3f