### PR TITLE
Ensure validator netlocs are trusted on identity updates

### DIFF
--- a/blockchain_node/blockchain.py
+++ b/blockchain_node/blockchain.py
@@ -712,7 +712,10 @@ class Blockchain:
         self.validator_id = validator_id
         self.validator_private_key_hex = private_key_hex
         if netloc:
-            self.validator_netloc = normalize_netloc(netloc)
+            normalized_netloc = normalize_netloc(netloc)
+            self.validator_netloc = normalized_netloc
+            if normalized_netloc not in self.trusted_nodes:
+                self.add_trusted_node(normalized_netloc)
 
         if public_key_hex:
             self.validator_public_key_hex = public_key_hex

--- a/tests/test_blockchain.py
+++ b/tests/test_blockchain.py
@@ -200,6 +200,26 @@ def test_sync_files_skips_owner_when_local_node(isolated_blockchain, monkeypatch
     assert scheduled == [("peer-b:5000", 1)]
 
 
+def test_set_validator_identity_auto_trusts_netloc(isolated_blockchain):
+    bc, module = isolated_blockchain
+
+    rsa_key = RSA.generate(1024)
+    private_key_hex = binascii.hexlify(rsa_key.export_key(format='DER')).decode('ascii')
+    public_key_hex = binascii.hexlify(rsa_key.publickey().export_key(format='DER')).decode('ascii')
+
+    bc.trusted_nodes = set()
+
+    bc.set_validator_identity(
+        "validator-with-netloc",
+        private_key_hex,
+        netloc="https://validator-host:7000/",
+        public_key_hex=public_key_hex,
+    )
+
+    assert "validator-host:7000" in bc.trusted_nodes
+    assert bc.is_authorized_validator()
+
+
 def test_sync_files_rejects_paths_outside_uploads(isolated_blockchain, monkeypatch, tmp_path):
     bc, module = isolated_blockchain
 


### PR DESCRIPTION
## Summary
- ensure validator identities register their configured netloc as a trusted node when stored
- add a regression test confirming validators with netlocs are authorized immediately

## Testing
- pytest tests/test_blockchain.py

------
https://chatgpt.com/codex/tasks/task_e_68de3bd23eec83229f99b7dc7ade711f