### PR TITLE
Resolve trusted hostnames for trusted node checks

### DIFF
--- a/tests/test_trusted_resolution.py
+++ b/tests/test_trusted_resolution.py
@@ -1,0 +1,70 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture
+def isolated_app(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    module_name = "blockchain_node.blockchain"
+    module = importlib.import_module(module_name)
+    module = importlib.reload(module)
+
+    module.DATA_FILE = "blockchain_data.json"
+    module.KEYS_DB_FILE = "keys_db.json"
+
+    os.makedirs(module.PENDING_FOLDER, exist_ok=True)
+    os.makedirs(module.UPLOAD_FOLDER, exist_ok=True)
+
+    blockchain_instance = module.Blockchain()
+    module.blockchain = blockchain_instance
+    blockchain_instance.transactions = []
+    blockchain_instance.nodes = set()
+    blockchain_instance.trusted_nodes = set()
+
+    return module
+
+
+def test_hostname_resolution_allows_trusted_access(isolated_app, monkeypatch):
+    module = isolated_app
+    blockchain = module.blockchain
+
+    trusted_netloc = "trusted.example.com:5000"
+    blockchain.add_trusted_node(trusted_netloc)
+
+    resolved_ip = "203.0.113.7"
+    lookup_calls = []
+
+    def fake_gethostbyname_ex(host):
+        lookup_calls.append(host)
+        if host != "trusted.example.com":
+            raise AssertionError(f"Unexpected lookup for host {host}")
+        return host, [], [resolved_ip]
+
+    monkeypatch.setattr(module.socket, "gethostbyname_ex", fake_gethostbyname_ex)
+
+    client = module.app.test_client()
+
+    response = client.get(
+        "/trusted_nodes/keys",
+        environ_base={"REMOTE_ADDR": resolved_ip},
+    )
+    assert response.status_code == 200
+    body = response.get_json()
+    assert isinstance(body, dict)
+    assert "validator_public_keys" in body
+
+    second = client.get(
+        "/trusted_nodes/keys",
+        environ_base={"REMOTE_ADDR": resolved_ip},
+    )
+    assert second.status_code == 200
+    assert lookup_calls == ["trusted.example.com"], "DNS lookup should be cached after first resolution"


### PR DESCRIPTION
## Summary
- normalize trusted node lookups by resolving hostnames to IPs with caching in the blockchain node
- clear cached resolutions when trusted entries change and handle empty remote addresses safely
- add pytest coverage that stubs DNS resolution and verifies trusted hostname access via the Flask client

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de469906ac83229f09083d61d70a0a