### PR TITLE
Handle IPv6 trusted node resolution

### DIFF
--- a/tests/test_trusted_resolution.py
+++ b/tests/test_trusted_resolution.py
@@ -68,3 +68,21 @@ def test_hostname_resolution_allows_trusted_access(isolated_app, monkeypatch):
     )
     assert second.status_code == 200
     assert lookup_calls == ["trusted.example.com"], "DNS lookup should be cached after first resolution"
+
+
+def test_ipv6_bracketed_trusted_registration(isolated_app):
+    module = isolated_app
+    blockchain = module.blockchain
+
+    blockchain.add_trusted_node("[::1]:5000")
+    assert "[::1]:5000" in blockchain.trusted_nodes
+
+    client = module.app.test_client()
+
+    response = client.get(
+        "/trusted_nodes/keys",
+        environ_base={"REMOTE_ADDR": "::1"},
+    )
+
+    assert response.status_code == 200
+    assert "::1" in blockchain.get_trusted_netloc_ips("[::1]:5000")


### PR DESCRIPTION
## Summary
- normalize node addresses using urllib.parse helpers so IPv4 and IPv6 hosts parse consistently
- ensure trusted node cache entries resolve bracketed IPv6 hosts and compare against Flask remote addresses
- add regression test that registers a bracketed IPv6 netloc and confirms ::1 requests are trusted

## Testing
- pytest tests/test_trusted_resolution.py

------
https://chatgpt.com/codex/tasks/task_e_68de4fcb82148322ab4927bba901bf7c