### PR TITLE
Handle invalid JSON responses during chain sync retries

### DIFF
--- a/blockchain_node/blockchain.py
+++ b/blockchain_node/blockchain.py
@@ -580,7 +580,17 @@ class Blockchain:
             try:
                 response = requests.get(url, timeout=self.sync_chain_timeout)
                 if response.status_code == 200:
-                    return response.json().get("chain", [])
+                    try:
+                        payload = response.json()
+                    except (ValueError, json.JSONDecodeError) as exc:
+                        self._record_sync_failure(
+                            "chain",
+                            netloc,
+                            error=exc,
+                            attempt=attempt,
+                        )
+                        continue
+                    return payload.get("chain", [])
                 self._record_sync_failure("chain", netloc, error=f"HTTP {response.status_code}", attempt=attempt)
             except requests.exceptions.RequestException as exc:
                 self._record_sync_failure("chain", netloc, error=exc, attempt=attempt)


### PR DESCRIPTION
## Summary
- record sync failures when a peer returns invalid JSON for the chain endpoint and retry instead of raising
- cover the new behavior with a unit test that injects an invalid JSON response

## Testing
- pytest tests/test_thread_safety.py::UploadConsensusHammerTest::test_fetch_chain_with_retry_handles_invalid_json

------
https://chatgpt.com/codex/tasks/task_e_68de5e95f2bc832295879ccc877b4e9b