### PR TITLE
Remove sensitive AES logging in client

### DIFF
--- a/Blockchain_client/blockchain_client.py
+++ b/Blockchain_client/blockchain_client.py
@@ -148,10 +148,10 @@ def upload_form():
         enc_nonce_b64 = nonce_b64
         enc_tag_b64   = tag_b64
 
-        app.logger.info(f"SENSITIVE file => {local_abs}")
-        app.logger.info(f"  encryption key (base64) = {key_b64}")
-        app.logger.info(f"  nonce = {nonce_b64}")
-        app.logger.info(f"  tag   = {tag_b64}")
+        if app.debug:
+            app.logger.debug("Sensitive file encrypted for upload")
+        else:
+            app.logger.info("Sensitive file encrypted for upload")
     else:
         # No encryption
         with open(local_abs, 'wb') as f:


### PR DESCRIPTION
## Summary
- stop logging encryption key, nonce, tag, and temp file path when handling sensitive uploads
- replace detailed payload logging with a generic event message while preserving debug visibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de61bb6b44832289aace5ef41a9db8