### PR TITLE
Enforce trusted node management authorization

### DIFF
--- a/blockchain_node/blockchain.py
+++ b/blockchain_node/blockchain.py
@@ -1332,6 +1332,9 @@ node_identifier = str(uuid4()).replace('-', '')
 app.config['JSONIFY_PRETTYPRINT_REGULAR'] = True
 
 
+_TRUSTED_MANAGEMENT_FORBIDDEN_MESSAGE = "Caller is not authorized to manage trusted nodes"
+
+
 def _request_from_trusted():
     caller_ip = request.remote_addr
     if not caller_ip:
@@ -1352,6 +1355,10 @@ def _request_from_trusted():
         if caller_ip in resolved_ips:
             return True
     return False
+
+
+def _trusted_management_forbidden_response():
+    return jsonify({"message": _TRUSTED_MANAGEMENT_FORBIDDEN_MESSAGE}), 403
 
 @app.route('/')
 def node_index():
@@ -1825,7 +1832,7 @@ def get_nodes():
 @app.route('/trusted_nodes/register', methods=['POST'])
 def register_trusted_nodes():
     if not _request_from_trusted():
-        return jsonify({"message": "Caller is not authorized to manage trusted nodes"}),403
+        return _trusted_management_forbidden_response()
     node_netlocs = []
 
     payload = request.get_json(silent=True)
@@ -1860,7 +1867,7 @@ def register_trusted_nodes():
 @app.route('/trusted_nodes/remove', methods=['POST'])
 def remove_trusted_node():
     if not _request_from_trusted():
-        return jsonify({"message": "Caller is not authorized to manage trusted nodes"}),403
+        return _trusted_management_forbidden_response()
     d = request.get_json() or {}
     if 'node' not in d:
         return jsonify({"message":"Missing node address"}),400

--- a/tests/test_trusted_resolution.py
+++ b/tests/test_trusted_resolution.py
@@ -133,6 +133,8 @@ def test_untrusted_caller_blocked_from_trusted_management(isolated_app):
     module = isolated_app
     client = module.app.test_client()
 
+    forbidden_message = module._TRUSTED_MANAGEMENT_FORBIDDEN_MESSAGE
+
     response = client.post(
         "/trusted_nodes/register",
         json={"nodes": ["203.0.113.99:5000"]},
@@ -140,7 +142,7 @@ def test_untrusted_caller_blocked_from_trusted_management(isolated_app):
     )
 
     assert response.status_code == 403
-    assert response.get_json()["message"] == "Caller is not authorized to manage trusted nodes"
+    assert response.get_json()["message"] == forbidden_message
 
     module.blockchain.add_trusted_node("198.51.100.10:5000")
 
@@ -151,7 +153,7 @@ def test_untrusted_caller_blocked_from_trusted_management(isolated_app):
     )
 
     assert removal.status_code == 403
-    assert removal.get_json()["message"] == "Caller is not authorized to manage trusted nodes"
+    assert removal.get_json()["message"] == forbidden_message
 
 
 def test_trusted_caller_can_manage_trusted_nodes(isolated_app):


### PR DESCRIPTION
## Summary
- add a shared forbidden response helper for trusted node administration
- ensure register/remove endpoints gate access with the helper and expose the message constant
- update trusted resolution tests to assert the shared message for unauthorized callers

## Testing
- pytest tests/test_trusted_resolution.py

------
https://chatgpt.com/codex/tasks/task_e_68deb6ad5df88322b34b2d577d92db5c