### PR TITLE
Support IPv6 resolution for trusted nodes

### DIFF
--- a/blockchain_node/blockchain.py
+++ b/blockchain_node/blockchain.py
@@ -1309,10 +1309,26 @@ class Blockchain:
         try:
             ip_obj = ipaddress.ip_address(stripped_host)
         except ValueError:
+            ip_list = []
             try:
-                _name, _alias, ip_list = socket.gethostbyname_ex(stripped_host)
+                addrinfo_list = socket.getaddrinfo(
+                    stripped_host,
+                    None,
+                    family=socket.AF_UNSPEC,
+                    type=0,
+                )
             except (socket.gaierror, UnicodeError):
-                ip_list = []
+                addrinfo_list = []
+
+            for family, _socktype, _proto, _canonname, sockaddr in addrinfo_list:
+                if not sockaddr:
+                    continue
+                raw_ip = sockaddr[0]
+                try:
+                    normalized_ip = ipaddress.ip_address(raw_ip)
+                except ValueError:
+                    continue
+                ip_list.append(str(normalized_ip))
         else:
             ip_list = [str(ip_obj)]
 


### PR DESCRIPTION
## Summary
- resolve trusted hostnames with socket.getaddrinfo to capture IPv4 and IPv6 results
- normalize resolved addresses before caching so IPv6-only hosts are accepted
- extend trusted resolution tests to cover IPv6-only hostnames and caching behaviour

## Testing
- pytest tests/test_trusted_resolution.py

------
https://chatgpt.com/codex/tasks/task_e_68df8daed32c832281157e92c9e4233a