### PR TITLE
Block mining sender spoofing prevention

### DIFF
--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -57,6 +57,7 @@ class UploadConsensusHammerTest(unittest.TestCase):
                     recipient_alias=f"recipient-alias-{prefix}",
                     signature="",
                     is_sensitive="0",
+                    allow_system_transaction=True,
                 )
 
         def consensus_worker():


### PR DESCRIPTION
## Summary
- reject transactions that spoof the mining sender and guard the upload/transaction endpoints against the reserved identity
- add an internal-only escape hatch for validator rewards and adapt mining/threads tests accordingly
- refresh upload security coverage with signed payload helpers and new cases that ensure reserved senders are rejected

## Testing
- PYTHONPATH=. pytest tests/test_upload_security.py tests/test_blockchain.py tests/test_thread_safety.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb1fa608083229870da7df779fd71