### PR TITLE
Normalize node registration parsing and add validation tests

### DIFF
--- a/tests/test_node_management.py
+++ b/tests/test_node_management.py
@@ -1,0 +1,94 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture
+def isolated_app(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    module_name = "blockchain_node.blockchain"
+    module = importlib.import_module(module_name)
+    module = importlib.reload(module)
+
+    module.DATA_FILE = "blockchain_data.json"
+    module.KEYS_DB_FILE = "keys_db.json"
+
+    os.makedirs(module.PENDING_FOLDER, exist_ok=True)
+    os.makedirs(module.UPLOAD_FOLDER, exist_ok=True)
+
+    blockchain_instance = module.Blockchain()
+    module.blockchain = blockchain_instance
+    blockchain_instance.transactions = []
+    blockchain_instance.nodes = set()
+    blockchain_instance.trusted_nodes = set()
+
+    return module
+
+
+def _trusted_environ():
+    return {"REMOTE_ADDR": "127.0.0.1"}
+
+
+def test_nodes_register_accepts_json_string_payload(isolated_app):
+    module = isolated_app
+    client = module.app.test_client()
+
+    response = client.post(
+        "/nodes/register",
+        data='"example.com:6000"',
+        content_type="application/json",
+        environ_base=_trusted_environ(),
+    )
+
+    assert response.status_code == 201
+    body = response.get_json()
+    assert body["message"] == "Nodes added"
+    assert "example.com:6000" in module.blockchain.nodes
+
+
+def test_nodes_register_rejects_invalid_netloc(isolated_app):
+    module = isolated_app
+    client = module.app.test_client()
+
+    initial_nodes = set(module.blockchain.nodes)
+
+    response = client.post(
+        "/nodes/register",
+        data='"http://:5000"',
+        content_type="application/json",
+        environ_base=_trusted_environ(),
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert "Invalid node address" in body["message"]
+    assert module.blockchain.nodes == initial_nodes
+
+
+def test_trusted_register_rejects_invalid_netloc(isolated_app):
+    module = isolated_app
+    module.blockchain.add_trusted_node("127.0.0.1:5000")
+    client = module.app.test_client()
+
+    initial_trusted = set(module.blockchain.trusted_nodes)
+
+    response = client.post(
+        "/trusted_nodes/register",
+        data='"http://:5000"',
+        content_type="application/json",
+        environ_base=_trusted_environ(),
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert "Invalid trusted node address" in body["message"]
+    assert module.blockchain.trusted_nodes == initial_trusted


### PR DESCRIPTION
## Summary
- normalize node and trusted node registration payloads to support JSON strings, arrays, and form data
- validate all candidate netlocs before mutating node sets and return clear 400 errors on invalid input
- add node management tests covering JSON string submissions and invalid netloc rejection

## Testing
- pytest tests/test_node_management.py

------
https://chatgpt.com/codex/tasks/task_e_68e00ec98dc48322a02310479653afd6