### PR TITLE
Validate validator private key configuration

### DIFF
--- a/blockchain_node/blockchain.py
+++ b/blockchain_node/blockchain.py
@@ -1110,7 +1110,9 @@ class Blockchain:
             try:
                 derived_public_key_hex = self.derive_public_key_hex(private_key_hex)
             except (ValueError, TypeError, binascii.Error) as exc:
-                logging.error(f"Could not derive public key from supplied private key: {exc}")
+                raise ValueError("Could not derive public key from supplied private key") from exc
+            if derived_public_key_hex is None:
+                raise ValueError("Could not derive public key from supplied private key")
 
         resolved_public_key_hex = None
         if public_key_hex:


### PR DESCRIPTION
## Summary
- raise a ValueError when deriving the validator public key fails so configuration errors surface to callers
- update validator configuration tests to use generated RSA keys and cover invalid private key submissions

## Testing
- pytest tests/test_trusted_resolution.py tests/test_validator_configuration.py

------
https://chatgpt.com/codex/tasks/task_e_68e0148c5b4c83228f1d248df107b676